### PR TITLE
UNAM Cluster in Makefile

### DIFF
--- a/pion/Makefile
+++ b/pion/Makefile
@@ -18,10 +18,10 @@ endif
 ifeq ($(SGE_CLUSTER_NAME),isabella)
 	LIB = /usr/lib64/
 endif
-# cluster at UNAM (Mexico City) - Jaime, plese complete!!!
-#ifeq ($(SGE_CLUSTER_NAME),???)
-#	LIB = /usr/lib64/
-#endif
+# cluster at UNAM (Mexico City) - 
+ifeq ($(SITE_NAME),ICN-UNAM)
+	LIB = /software/icn/lapack/3.9/
+endif
 LAPACK = $(LIB)liblapack.so.3
 MYLIB = ../cbl-mylib/mylib.a
 ########################################################################


### PR DESCRIPTION
Hello. Our Cluster at UNAM does not work with SGE, instead it uses TORQUE/PBS, so there was no SGE_CLUSTER_NAME variable. The most useful variable that I found by typing  "env" was SITE_NAME, which is the one I wrote in the Makefile.

Regards.